### PR TITLE
Enforce always template curly spacing

### DIFF
--- a/index.js
+++ b/index.js
@@ -84,6 +84,7 @@ module.exports = {
 		} ],
 		// Assumed by default with Babel
 		strict: [ 2, 'never' ],
+		'template-curly-spacing': [ 2, 'always' ],
 		'valid-jsdoc': [ 2, { requireReturn: false } ],
 		'wpcalypso/i18n-ellipsis': 2,
 		'wpcalypso/i18n-no-variables': 2,


### PR DESCRIPTION
This pull request seeks to enable the `template-curly-spacing` rule:

http://eslint.org/docs/rules/template-curly-spacing

For consistency with our other spacing guidelines, we should always seek to have a space between curly braces in string template interpolation.

Related guidelines:
- https://github.com/Automattic/wp-calypso/blob/master/docs/coding-guidelines/javascript.md#spacing
- https://github.com/Automattic/wp-calypso/blob/master/docs/coding-guidelines/javascript.md#arrays-and-function-calls