### PR TITLE
Add accessibility linters as a possible configuration file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+#### v0.7.0 (2017-03-20)
+
+- Added: [`eslint-plugin-jsx-a11y`](https://github.com/evcohen/eslint-plugin-jsx-a11y) rules to check for common accessibility issues, as warnings
+
 #### v0.6.0 (2016-10-21)
 
 - General: Update to `eslint-plugin-wpcalypso@3.0.1` ([see changelog](https://github.com/Automattic/eslint-plugin-wpcalypso/blob/master/CHANGELOG.md#v301-2016-10-21))

--- a/README.md
+++ b/README.md
@@ -29,6 +29,21 @@ Or, if your project uses React and you want to opt in to additional React-specif
 "extends": "wpcalypso/react"
 ```
 
+You can also add in some accessibility rules, for example using both the React superset and the set of jsx-a11y rules:
+
+```
+"extends": [
+	"wpcalypso/react",
+	"wpcalypso/a11y"
+]
+```
+
+For these accessibility rules, you will need to also install [the jsx-a11y plugin](https://github.com/evcohen/eslint-plugin-jsx-a11y):
+
+```
+npm install --save-dev eslint-plugin-jsx-a11y
+```
+
 Refer to the [ESLint documentation on Shareable Configs](http://eslint.org/docs/developer-guide/shareable-configs) for more information.
 
 ## Suggesting Changes

--- a/README.md
+++ b/README.md
@@ -29,13 +29,10 @@ Or, if your project uses React and you want to opt in to additional React-specif
 "extends": "wpcalypso/react"
 ```
 
-You can also add in some accessibility rules, for example using both the React superset and the set of jsx-a11y rules:
+Another set of rules available is the `react-a11y` set, which contains the base rules, the react rules, and a set of accessibility checks. To use these:
 
 ```
-"extends": [
-	"wpcalypso/react",
-	"wpcalypso/a11y"
-]
+"extends": "wpcalypso/react-a11y"
 ```
 
 For these accessibility rules, you will need to also install [the jsx-a11y plugin](https://github.com/evcohen/eslint-plugin-jsx-a11y):

--- a/a11y/index.js
+++ b/a11y/index.js
@@ -1,0 +1,36 @@
+module.exports = {
+	plugins: [
+		'jsx-a11y'
+	],
+	rules: {
+		'jsx-a11y/accessible-emoji': 1,
+		// 'jsx-a11y/anchor-has-content' doesn't handle our translation system
+		'jsx-a11y/aria-activedescendant-has-tabindex': 1,
+		'jsx-a11y/aria-props': 1,
+		'jsx-a11y/aria-proptypes': 1,
+		'jsx-a11y/aria-role': 1,
+		'jsx-a11y/aria-unsupported-elements': 1,
+		'jsx-a11y/click-events-have-key-events': 1,
+		'jsx-a11y/heading-has-content': 1,
+		'jsx-a11y/href-no-hash': 1,
+		'jsx-a11y/html-has-lang': 1,
+		'jsx-a11y/iframe-has-title': 1,
+		'jsx-a11y/img-has-alt': 1,
+		'jsx-a11y/img-redundant-alt': 1,
+		'jsx-a11y/label-has-for': 1,
+		'jsx-a11y/lang': 1,
+		'jsx-a11y/mouse-events-have-key-events': 1,
+		'jsx-a11y/no-access-key': 1,
+		// 'jsx-a11y/no-autofocus' Replace this with a rule that detects if all autofocus have a describedby
+		'jsx-a11y/no-distracting-elements': 1,
+		'jsx-a11y/no-onchange': 1,
+		'jsx-a11y/no-redundant-roles': 1,
+		// 'jsx-a11y/no-static-element-interactions' Not needed right now if the following two rules are set
+		'jsx-a11y/onclick-has-focus': 1,
+		'jsx-a11y/onclick-has-role': 1,
+		'jsx-a11y/role-has-required-aria-props': 1,
+		'jsx-a11y/role-supports-aria-props': 1,
+		'jsx-a11y/scope': 1,
+		'jsx-a11y/tabindex-no-positive': 1,
+	}
+};

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
   },
   "peerDependencies": {
     "eslint": "^3.3.1",
-    "eslint-plugin-wpcalypso": "^3.0.1",
-    "eslint-plugin-jsx-a11y": "^4.0.0"
+    "eslint-plugin-wpcalypso": "^3.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-wpcalypso",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "ESLint configuration following WordPress.com's Calypso JavaScript Coding Guidelines",
   "keywords": [
     "eslint"

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "files": [
     "index.js",
     "react/index.js",
-    "a11y/index.js"
+    "react-a11y/index.js"
   ],
   "license": "GPL-2.0+",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -14,8 +14,9 @@
     }
   ],
   "files": [
-  	"index.js",
-  	"react/index.js"
+    "index.js",
+    "react/index.js",
+    "a11y/index.js"
   ],
   "license": "GPL-2.0+",
   "repository": {
@@ -24,6 +25,7 @@
   },
   "peerDependencies": {
     "eslint": "^3.3.1",
-    "eslint-plugin-wpcalypso": "^3.0.1"
+    "eslint-plugin-wpcalypso": "^3.0.1",
+    "eslint-plugin-jsx-a11y": "^4.0.0"
   }
 }

--- a/react-a11y/index.js
+++ b/react-a11y/index.js
@@ -1,4 +1,5 @@
 module.exports = {
+	'extends': '../react/index.js',
 	plugins: [
 		'jsx-a11y'
 	],


### PR DESCRIPTION
This PR enables the [jsx-a11y](https://github.com/evcohen/eslint-plugin-jsx-a11y) rules for ESLint. This will let us quickly check for a handful of accessibility issues common in javascript apps. It won't get us to 100% accessible, but it's a good step for awareness of these issues.

~~This can be used in conjunction with the react rules:~~ This is now a superset of the react rules, so you would use it like so:

```
"extends": "wpcalypso/react-a11y"
```

See [the supported rules](https://github.com/evcohen/eslint-plugin-jsx-a11y#supported-rules) for the various issues this can check for. Most of these have been turned on, though some don't quite apply to calypso and I've noted that in `a11y/index.js`. They are are currently implemented as warnings, but if these seem helpful for our accessibility, we can bump to errors as the basics are fixed.