### PR TITLE
Set comma-dangle to 'always-multiline'

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ module.exports = {
 		'array-bracket-spacing': [ 2, 'always' ],
 		'brace-style': [ 2, '1tbs' ],
 		camelcase: 2,
-		'comma-dangle': 0,
+		'comma-dangle': [ 2, 'always-multiline' ],
 		'comma-spacing': 2,
 		'comma-style': 2,
 		'computed-property-spacing': [ 2, 'always' ],


### PR DESCRIPTION
Require a trailing comma for multiline object literals (but not single line).

Docs here:

http://eslint.org/docs/rules/comma-dangle

Good writeup on the rationale here:

https://medium.com/@nikgraf/why-you-should-enforce-dangling-commas-for-multiline-statements-d034c98e36f8