### PR TITLE
Add react/no-deprecated rule as error

### DIFF
--- a/react/index.js
+++ b/react/index.js
@@ -21,6 +21,7 @@ module.exports = {
 		'react/jsx-uses-react': 2,
 		'react/jsx-uses-vars': 2,
 		'react/no-danger': 2,
+		'react/no-deprecated': 2,
 		'react/no-did-mount-set-state': 2,
 		'react/no-did-update-set-state': 2,
 		'react/no-is-mounted': 2,


### PR DESCRIPTION
So we're not perpetuating deprecated patterns.
See https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-deprecated.md

Related to https://github.com/Automattic/wp-calypso/issues/5951 and https://github.com/Automattic/wp-calypso/pull/13925, /cc @jsnajdr and @jsnmoon

@aduth If I want to do a release for this, do I bump the minor or point number?