### PR TITLE
Add wpcalypso/redux-no-bound-selectors rule as error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+#### v0.9.0 (2017-06-14)
+
+- Added: [`wpcalypso/redux-no-bound-selectors`](https://github.com/Automattic/eslint-plugin-wpcalypso/blob/master/docs/rules/redux-no-bound-selectors.md) as error
+
 #### v0.8.0 (2017-05-18)
 
 - Added: [`react/no-deprecated`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-deprecated.md) as error

--- a/index.js
+++ b/index.js
@@ -97,6 +97,7 @@ module.exports = {
 		'wpcalypso/import-docblock': 2,
 		'wpcalypso/jsx-gridicon-size': 2,
 		'wpcalypso/jsx-classname-namespace': 2,
+		'wpcalypso/redux-no-bound-selectors': 2,
 		yoda: 0
 	}
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-wpcalypso",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "ESLint configuration following WordPress.com's Calypso JavaScript Coding Guidelines",
   "keywords": [
     "eslint"


### PR DESCRIPTION
See https://github.com/Automattic/eslint-plugin-wpcalypso/pull/38/ and https://github.com/Automattic/wp-calypso/issues/14024