### PR TITLE
Add react/no-string-refs as error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 #### v0.9.0 (2017-06-14)
 
 - Added: [`wpcalypso/redux-no-bound-selectors`](https://github.com/Automattic/eslint-plugin-wpcalypso/blob/master/docs/rules/redux-no-bound-selectors.md) as error
+- Added: [`react/no-string-refs`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-string-refs.md) as error
 
 #### v0.8.0 (2017-05-18)
 

--- a/react/index.js
+++ b/react/index.js
@@ -25,6 +25,7 @@ module.exports = {
 		'react/no-did-mount-set-state': 2,
 		'react/no-did-update-set-state': 2,
 		'react/no-is-mounted': 2,
+		'react/no-string-refs': 2,
 		'react/prefer-es6-class': 2,
 		'react/react-in-jsx-scope': 2
 	}


### PR DESCRIPTION
Using string refs (`ref="foo"` and then `this.refs.foo`) is legacy, and is "likely to be removed in one of the future releases" ([React Legacy API: String Refs](https://facebook.github.io/react/docs/refs-and-the-dom.html#legacy-api-string-refs))

We currently use string refs pretty extensively across calypso, but we should stop digging that hole.

From: https://github.com/Automattic/wp-calypso/pull/15089