### PR TITLE
Add react/jsx-indent error

### DIFF
--- a/react/index.js
+++ b/react/index.js
@@ -13,6 +13,7 @@ module.exports = {
 	],
 	rules: {
 		'react/jsx-curly-spacing': [ 2, 'always' ],
+		'react/jsx-indent': [ 'error', 'tab' ],
 		'react/jsx-no-bind': 2,
 		'react/jsx-no-duplicate-props': 2,
 		'react/jsx-no-target-blank': 2,


### PR DESCRIPTION
As @aduth suggested at https://github.com/Automattic/wp-calypso/pull/16550#issuecomment-318448439

To test just replace some tab indentation with spaces in a `.jsx` file and should see something like this
![screenshot](https://user-images.githubusercontent.com/454800/28586345-bf226946-7173-11e7-8ab1-b16ac312331f.jpg)