### PR TITLE
remove quote-props rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+#### v1.1.0 (2017-10-03)
+
+- Removed: `quote-props` will no longer flag keyword properties as error ([reference](https://eslint.org/docs/rules/quote-props#keywords))
+
 #### v1.0.0 (2017-09-07)
 
 - Breaking: Upgraded ESLint peer dependency from 3.x to 4.x. [See v4.0.0 Migration Guide](https://eslint.org/docs/user-guide/migrating-to-4.0.0)

--- a/index.js
+++ b/index.js
@@ -70,7 +70,7 @@ module.exports = {
 		} } ],
 		'padded-blocks': [ 2, 'never' ],
 		'prefer-const': 2,
-		'quote-props': [ 2, 'as-needed', { keywords: false } ],
+		'quote-props': [ 2, 'as-needed' ],
 		quotes: [ 2, 'single', 'avoid-escape' ],
 		semi: 2,
 		'semi-spacing': 2,

--- a/index.js
+++ b/index.js
@@ -70,7 +70,7 @@ module.exports = {
 		} } ],
 		'padded-blocks': [ 2, 'never' ],
 		'prefer-const': 2,
-		'quote-props': [ 2, 'as-needed', { keywords: true } ],
+		'quote-props': [ 2, 'as-needed', { keywords: false } ],
 		quotes: [ 2, 'single', 'avoid-escape' ],
 		semi: 2,
 		'semi-spacing': 2,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "eslint-config-wpcalypso",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 1
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-wpcalypso",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "ESLint configuration following WordPress.com's Calypso JavaScript Coding Guidelines",
   "keywords": [
     "eslint"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-wpcalypso",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "ESLint configuration following WordPress.com's Calypso JavaScript Coding Guidelines",
   "keywords": [
     "eslint"


### PR DESCRIPTION
This PR seeks to remove an eslint rule that I do not believe is necessary.
Specifically the restriction on requiring quotes around language keywords used as object property names.


ESLint Rule: https://eslint.org/docs/rules/quote-props
Compatibility Table: http://kangax.github.io/compat-table/es5/#test-Object/array_literal_extensions_Reserved_words_as_property_names . (ie9+).