### PR TITLE
Loosen peers to allow for v3 of eslint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+#### v1.1.1 (2017-10-30)
+
+- Allow for eslint 3.x as a peer dependency instead of only 4.x
+
 #### v1.1.0 (2017-10-03)
 
 - Removed: `quote-props` will no longer flag keyword properties as error ([reference](https://eslint.org/docs/rules/quote-props#keywords))

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "eslint-config-wpcalypso",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 1
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-wpcalypso",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "ESLint configuration following WordPress.com's Calypso JavaScript Coding Guidelines",
   "keywords": [
     "eslint"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "url": "https://github.com/Automattic/eslint-config-wpcalypso.git"
   },
   "peerDependencies": {
-    "eslint": "^4.6.1",
-    "eslint-plugin-wpcalypso": "^4.0.0"
+    "eslint": "^3.3.1 || ^4.6.1",
+    "eslint-plugin-wpcalypso": "^3.4.1 || ^4.0.0"
   }
 }


### PR DESCRIPTION
See https://github.com/Automattic/eslint-config-wpcalypso/commit/b6a59ff8c41320fedae1ae0755b9c8c997d852fb

>can we make it compatible with both v3 and v4 instead? wp-calypso is currently blocked from using v4 do to: Automattic/wp-calypso#18106
