### PR TITLE
Add no-duplicate-imports rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,6 +38,7 @@ module.exports = {
 		'no-dupe-args': 2,
 		'no-dupe-keys': 2,
 		'no-duplicate-case': 2,
+		'no-duplicate-imports': 2,
 		'no-else-return': 2,
 		'no-empty': [ 2, { allowEmptyCatch: true } ],
 		'no-extra-semi': 2,


### PR DESCRIPTION
Adds the [`no-duplicate-imports` rule](https://eslint.org/docs/rules/no-duplicate-imports).

Example of lint errors: 

```js
import { merge } from 'module';
import something from 'another-module';
import { find } from 'module';
```

This would have helped prevent this recently introduced bug: https://github.com/Automattic/wp-calypso/pull/19305