### PR TITLE
Bump minor and add CHANGELOG for 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+#### v1.2.0 (2017-11-03)
+
+- Added: [`no-duplicate-imports`](https://eslint.org/docs/rules/no-duplicate-imports) as error
+
 #### v1.1.1 (2017-10-30)
 
 - Allow for eslint 3.x as a peer dependency instead of only 4.x

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "eslint-config-wpcalypso",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "lockfileVersion": 1
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-wpcalypso",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "ESLint configuration following WordPress.com's Calypso JavaScript Coding Guidelines",
   "keywords": [
     "eslint"


### PR DESCRIPTION
`1.2.0` includes the `no-duplicate-imports` rule.