### PR TITLE
Remove deprecated rule

### DIFF
--- a/react/index.js
+++ b/react/index.js
@@ -17,7 +17,7 @@ module.exports = {
 		'react/jsx-no-duplicate-props': 2,
 		'react/jsx-no-target-blank': 2,
 		'react/jsx-no-undef': 2,
-		'react/jsx-space-before-closing': 2,
+		'react/jsx-tag-spacing': 2,
 		'react/jsx-uses-react': 2,
 		'react/jsx-uses-vars': 2,
 		'react/no-danger': 2,


### PR DESCRIPTION
Use the new rule: 

- `'react/jsx-tag-spacing'` in favor of `'react/jsx-space-before-closing'`.

The rule is deprecated: 

- https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-space-before-closing.md

And to avoid having notices of deprecation during the lint update with the new one.