### PR TITLE
Allow binds in jsx props. It's not the perf problem we thought it might be.

### DIFF
--- a/react/index.js
+++ b/react/index.js
@@ -13,7 +13,6 @@ module.exports = {
 	],
 	rules: {
 		'react/jsx-curly-spacing': [ 2, 'always' ],
-		'react/jsx-no-bind': 2,
 		'react/jsx-no-duplicate-props': 2,
 		'react/jsx-no-target-blank': 2,
 		'react/jsx-no-undef': 2,


### PR DESCRIPTION
Originally we turned this rule on because we were concerned it would break component purity and lead to tons of re-renders. However, we have not really seen that be a perf problem and it makes a number of common cases much harder to handle. 