### PR TITLE
Add space before parent always for async arrows

### DIFF
--- a/index.js
+++ b/index.js
@@ -76,7 +76,11 @@ module.exports = {
 		semi: 2,
 		'semi-spacing': 2,
 		'space-before-blocks': [ 2, 'always' ],
-		'space-before-function-paren': [ 2, 'never' ],
+		'space-before-function-paren': [ 'error', {
+			anonymous: 'never',
+			asyncArrow: 'always',
+			named: 'never',
+		} ],
 		'space-in-parens': [ 2, 'always' ],
 		'space-infix-ops': [ 2, { int32Hint: false } ],
 		'space-unary-ops': [ 2, {


### PR DESCRIPTION
Add a rule for async arrow paren spacing which is error for calypso-prettier formatted code. 
Example:

> /home/circleci/wp-calypso/client/state/test/utils.js
>  841:67  error  Unexpected space before function parentheses  space-before-function-paren
>  855:67  error  Unexpected space before function parentheses  space-before-function-paren
>  869:62  error  Unexpected space before function parentheses  space-before-function-paren
>  885:62  error  Unexpected space before function parentheses  space-before-function-paren
https://circleci.com/gh/Automattic/wp-calypso/92645#tests/containers/2

```js
		test( 'should call apropriate action creators on success', async () => {
```

https://github.com/Automattic/wp-calypso/blob/7d249d9f48e69ec6accac349c48797de797a31d1/client/state/test/utils.js#L841 from https://github.com/Automattic/wp-calypso/pull/24457

---

Docs:

> `asyncArrow` is for async arrow function expressions
> (e.g. `async () => {}`).

https://eslint.org/docs/rules/space-before-function-paren#options