### PR TITLE
Add ignoreRestSiblings flag to the no-unused-vars rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,7 +59,8 @@ module.exports = {
 		'no-undef': 2,
 		'no-underscore-dangle': 0,
 		'no-unreachable': 2,
-		'no-unused-vars': 2,
+		// Ignore rest siblings used to omit properties from objects: const { a, b, ...rest } = props
+		'no-unused-vars': [ 2, { ignoreRestSiblings: true } ],
 		// Allows function use before declaration
 		'no-use-before-define': [ 2, 'nofunc' ],
 		'no-var': 2,


### PR DESCRIPTION
Allow unused variables that are used to omit properties from an object:
```js
const { a, b, ...rest } = props;
```
`a` and `b` are unused variables, but yet ESLint doesn't complain about them,
because they are used to omit properties from the `props` object and assign
the new object to `rest`. That's a handy alternative to Lodash `omit`.