### PR TITLE
chore(peerDeps): allow eslint v5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 node_modules
 npm-debug.log
+/tags

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 .DS_Store
 node_modules
 npm-debug.log
-/tags

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "url": "https://github.com/Automattic/eslint-config-wpcalypso.git"
   },
   "peerDependencies": {
-    "eslint": "^3.3.1 || ^4.6.1",
+    "eslint": "^3.3.1 || ^4.6.1 || ^5.0.0",
     "eslint-plugin-wpcalypso": "^3.4.1 || ^4.0.0"
   }
 }


### PR DESCRIPTION
closes #21 

• ~~the `.gitignore` change is an unrelated drive-by change~~
• allow usage of eslint v5 for Calypso without a peer dep warning

### Testing instructions

I'm not sure how to test this but I think it's a good start to have a look at the [eslint v5 migration guide](https://eslint.org/docs/user-guide/migrating-to-5.0.0) and see if there's anything related to our rules defined here.